### PR TITLE
Defining entity objects to map to db tables

### DIFF
--- a/src/main/java/merrittwan/cs3200/Application.java
+++ b/src/main/java/merrittwan/cs3200/Application.java
@@ -4,6 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 
+/**
+ * Main application class.
+ */
 @SpringBootApplication
 @ComponentScan("merrittwan.cs3200")
 public class Application {

--- a/src/main/java/merrittwan/cs3200/config/JdbcConfig.java
+++ b/src/main/java/merrittwan/cs3200/config/JdbcConfig.java
@@ -9,6 +9,8 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import javax.sql.DataSource;
 
 /**
+ * Configuration for JDBC connection to MySQL database.
+ *
  * Created by olivi on 11/09/2017.
  */
 @Configuration

--- a/src/main/java/merrittwan/cs3200/config/SwaggerConfig.java
+++ b/src/main/java/merrittwan/cs3200/config/SwaggerConfig.java
@@ -26,7 +26,7 @@ public class SwaggerConfig {
     return new Docket(DocumentationType.SWAGGER_2)
             .select()
             .apis(RequestHandlerSelectors.any())
-            .paths(PathSelectors.ant("/**"))
+            .paths(PathSelectors.ant("/api/**"))
             .build()
             .apiInfo(buildApiInfo());
   }

--- a/src/main/java/merrittwan/cs3200/controller/address/AddressController.java
+++ b/src/main/java/merrittwan/cs3200/controller/address/AddressController.java
@@ -9,14 +9,14 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.List;
 
-import merrittwan.cs3200.repository.Address;
+import merrittwan.cs3200.entity.Address;
 import merrittwan.cs3200.service.address.AddressService;
 
 /**
  * Created by olivi on 11/15/2017.
  */
 @Controller
-@RequestMapping("/address")
+@RequestMapping("/api/address")
 public class AddressController {
 
   @Autowired

--- a/src/main/java/merrittwan/cs3200/controller/study/StudyController.java
+++ b/src/main/java/merrittwan/cs3200/controller/study/StudyController.java
@@ -1,0 +1,7 @@
+package merrittwan.cs3200.controller.study;
+
+/**
+ * Created by olivi on 11/28/2017.
+ */
+public class StudyController {
+}

--- a/src/main/java/merrittwan/cs3200/entity/Address.java
+++ b/src/main/java/merrittwan/cs3200/entity/Address.java
@@ -17,7 +17,7 @@ public class Address {
 
   private String state;
 
-  private int zip;
+  private String zip;
 
   public Address() {
 
@@ -55,11 +55,11 @@ public class Address {
     this.state = state;
   }
 
-  public int getZip() {
+  public String getZip() {
     return zip;
   }
 
-  public void setZip(int zip) {
+  public void setZip(String zip) {
     this.zip = zip;
   }
 }

--- a/src/main/java/merrittwan/cs3200/entity/Address.java
+++ b/src/main/java/merrittwan/cs3200/entity/Address.java
@@ -1,11 +1,15 @@
-package merrittwan.cs3200.repository;
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
+ * Class to represent rows in ADDRESS table.
  * Created by olivi on 11/15/2017.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Address {
 
-  private int addressId;
+  private Integer addressId;
 
   private String street;
 
@@ -19,11 +23,11 @@ public class Address {
 
   }
 
-  public int getAddressId() {
+  public Integer getAddressId() {
     return addressId;
   }
 
-  public void setAddressId(int addressId) {
+  public void setAddressId(Integer addressId) {
     this.addressId = addressId;
   }
 

--- a/src/main/java/merrittwan/cs3200/entity/Clinician.java
+++ b/src/main/java/merrittwan/cs3200/entity/Clinician.java
@@ -1,0 +1,45 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Class to represent rows in CLINICIAN table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Clinician {
+
+  private Integer clinicianId;
+
+  private String firstName;
+
+  private String lastName;
+
+  public Clinician() {
+
+  }
+
+  public Integer getClinicianId() {
+    return clinicianId;
+  }
+
+  public void setClinicianId(Integer clinicianId) {
+    this.clinicianId = clinicianId;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/entity/ClinicianPatientMeasuredValue.java
+++ b/src/main/java/merrittwan/cs3200/entity/ClinicianPatientMeasuredValue.java
@@ -1,0 +1,79 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.sql.Date;
+
+/**
+ * Class to represent rows in CLINICIAN_PATIENT_MEASURED_VALUE table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClinicianPatientMeasuredValue {
+
+  private Patient patient;
+
+  private MeasuredValue measuredValue;
+
+  private Clinician clinician;
+
+  private String value;
+
+  private String valueUnit;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+  private Date date;
+
+  public ClinicianPatientMeasuredValue() {
+
+  }
+
+  public Patient getPatient() {
+    return patient;
+  }
+
+  public void setPatient(Patient patient) {
+    this.patient = patient;
+  }
+
+  public MeasuredValue getMeasuredValue() {
+    return measuredValue;
+  }
+
+  public void setMeasuredValue(MeasuredValue measuredValue) {
+    this.measuredValue = measuredValue;
+  }
+
+  public Clinician getClinician() {
+    return clinician;
+  }
+
+  public void setClinician(Clinician clinician) {
+    this.clinician = clinician;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public String getValueUnit() {
+    return valueUnit;
+  }
+
+  public void setValueUnit(String valueUnit) {
+    this.valueUnit = valueUnit;
+  }
+
+  public Date getDate() {
+    return date;
+  }
+
+  public void setDate(Date date) {
+    this.date = date;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/entity/Drug.java
+++ b/src/main/java/merrittwan/cs3200/entity/Drug.java
@@ -1,0 +1,65 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Class to represent rows in DRUG table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Drug {
+
+  private int drugId;
+
+  private String marketName;
+
+  private String scientificName;
+
+  private String toxicity;
+
+  private int previousSuccess;
+
+  public Drug() {
+
+  }
+
+  public int getDrugId() {
+    return drugId;
+  }
+
+  public void setDrugId(int drugId) {
+    this.drugId = drugId;
+  }
+
+  public String getMarketName() {
+    return marketName;
+  }
+
+  public void setMarketName(String marketName) {
+    this.marketName = marketName;
+  }
+
+  public String getScientificName() {
+    return scientificName;
+  }
+
+  public void setScientificName(String scientificName) {
+    this.scientificName = scientificName;
+  }
+
+  public String getToxicity() {
+    return toxicity;
+  }
+
+  public void setToxicity(String toxicity) {
+    this.toxicity = toxicity;
+  }
+
+  public int getPreviousSuccess() {
+    return previousSuccess;
+  }
+
+  public void setPreviousSuccess(int previousSuccess) {
+    this.previousSuccess = previousSuccess;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/entity/Institution.java
+++ b/src/main/java/merrittwan/cs3200/entity/Institution.java
@@ -1,0 +1,59 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Class to represent rows in INSTITUTION table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Institution {
+
+  private Integer institutionId;
+
+  private String name;
+
+  private InstitutionType type;
+
+  public enum InstitutionType {
+    UNIVERSITY, HOSPITAL, PHARMA, OTHER
+  }
+
+  private Address address;
+
+  public Institution() {
+
+  }
+
+  public Integer getInstitutionId() {
+    return institutionId;
+  }
+
+  public void setInstitutionId(Integer institutionId) {
+    this.institutionId = institutionId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public InstitutionType getType() {
+    return type;
+  }
+
+  public void setType(InstitutionType type) {
+    this.type = type;
+  }
+
+  public Address getAddress() {
+    return address;
+  }
+
+  public void setAddress(Address address) {
+    this.address = address;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/entity/MeasuredValue.java
+++ b/src/main/java/merrittwan/cs3200/entity/MeasuredValue.java
@@ -1,0 +1,95 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Class to represent rows in MEASURED_VALUE table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MeasuredValue {
+
+  private int measuredValueId;
+
+  private String valueName;
+
+  private String valueDescription;
+
+  private String valueUnit;
+
+  private Patient patient;
+
+  private Clinician clinician;
+
+  private int maxHealthyAmount;
+
+  private int minHealthyAmount;
+
+  public MeasuredValue() {
+
+  }
+
+  public int getMeasuredValueId() {
+    return measuredValueId;
+  }
+
+  public void setMeasuredValueId(int measuredValueId) {
+    this.measuredValueId = measuredValueId;
+  }
+
+  public String getValueName() {
+    return valueName;
+  }
+
+  public void setValueName(String valueName) {
+    this.valueName = valueName;
+  }
+
+  public String getValueDescription() {
+    return valueDescription;
+  }
+
+  public void setValueDescription(String valueDescription) {
+    this.valueDescription = valueDescription;
+  }
+
+  public String getValueUnit() {
+    return valueUnit;
+  }
+
+  public void setValueUnit(String valueUnit) {
+    this.valueUnit = valueUnit;
+  }
+
+  public Patient getPatient() {
+    return patient;
+  }
+
+  public void setPatient(Patient patient) {
+    this.patient = patient;
+  }
+
+  public Clinician getClinician() {
+    return clinician;
+  }
+
+  public void setClinician(Clinician clinician) {
+    this.clinician = clinician;
+  }
+
+  public int getMaxHealthyAmount() {
+    return maxHealthyAmount;
+  }
+
+  public void setMaxHealthyAmount(int maxHealthyAmount) {
+    this.maxHealthyAmount = maxHealthyAmount;
+  }
+
+  public int getMinHealthyAmount() {
+    return minHealthyAmount;
+  }
+
+  public void setMinHealthyAmount(int minHealthyAmount) {
+    this.minHealthyAmount = minHealthyAmount;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/entity/MedicalCondition.java
+++ b/src/main/java/merrittwan/cs3200/entity/MedicalCondition.java
@@ -1,0 +1,45 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Class to represent rows in MEDICAL_CONDITION table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MedicalCondition {
+
+  private int conditionId;
+
+  private String name;
+
+  private String description;
+
+  public MedicalCondition() {
+
+  }
+
+  public int getConditionId() {
+    return conditionId;
+  }
+
+  public void setConditionId(int conditionId) {
+    this.conditionId = conditionId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/entity/Patient.java
+++ b/src/main/java/merrittwan/cs3200/entity/Patient.java
@@ -1,0 +1,151 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Date;
+
+/**
+ * Class to represent rows in PATIENT table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Patient {
+
+  private int patientId;
+
+  private String firstName;
+
+  private String lastName;
+
+  private Date dob;
+
+  private Sex sex;
+
+  private String hometown;
+
+  private String nationality;
+
+  private String race;
+
+  private String ethnicity;
+
+  private Study study;
+
+  private boolean placebo;
+
+  private Address address;
+
+  private boolean healthy;
+
+  public enum Sex {
+    MALE, FEMALE
+  }
+
+  public Patient() {
+
+  }
+
+  public int getPatientId() {
+    return patientId;
+  }
+
+  public void setPatientId(int patientId) {
+    this.patientId = patientId;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  public Date getDob() {
+    return dob;
+  }
+
+  public void setDob(Date dob) {
+    this.dob = dob;
+  }
+
+  public Sex getSex() {
+    return sex;
+  }
+
+  public void setSex(Sex sex) {
+    this.sex = sex;
+  }
+
+  public String getHometown() {
+    return hometown;
+  }
+
+  public void setHometown(String hometown) {
+    this.hometown = hometown;
+  }
+
+  public String getNationality() {
+    return nationality;
+  }
+
+  public void setNationality(String nationality) {
+    this.nationality = nationality;
+  }
+
+  public String getRace() {
+    return race;
+  }
+
+  public void setRace(String race) {
+    this.race = race;
+  }
+
+  public String getEthnicity() {
+    return ethnicity;
+  }
+
+  public void setEthnicity(String ethnicity) {
+    this.ethnicity = ethnicity;
+  }
+
+  public Study getStudy() {
+    return study;
+  }
+
+  public void setStudy(Study study) {
+    this.study = study;
+  }
+
+  public boolean isPlacebo() {
+    return placebo;
+  }
+
+  public void setPlacebo(boolean placebo) {
+    this.placebo = placebo;
+  }
+
+  public Address getAddress() {
+    return address;
+  }
+
+  public void setAddress(Address address) {
+    this.address = address;
+  }
+
+  public boolean isHealthy() {
+    return healthy;
+  }
+
+  public void setHealthy(boolean healthy) {
+    this.healthy = healthy;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/entity/PrincipalInvestigator.java
+++ b/src/main/java/merrittwan/cs3200/entity/PrincipalInvestigator.java
@@ -1,0 +1,85 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Class to represent data in the PRINCIPAL_INVESTIGATOR table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PrincipalInvestigator {
+
+  private int principalInvestigatorId;
+
+  private String firstName;
+
+  private String lastName;
+
+  private String phone;
+
+  private String email;
+
+  private Address address;
+
+  private Institution institution;
+
+  public PrincipalInvestigator() {
+
+  }
+
+  public int getPrincipalInvestigatorId() {
+    return principalInvestigatorId;
+  }
+
+  public void setPrincipalInvestigatorId(int principalInvestigatorId) {
+    this.principalInvestigatorId = principalInvestigatorId;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getPhone() {
+    return phone;
+  }
+
+  public void setPhone(String phone) {
+    this.phone = phone;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public Address getAddress() {
+    return address;
+  }
+
+  public void setAddress(Address address) {
+    this.address = address;
+  }
+
+  public Institution getInstitution() {
+    return institution;
+  }
+
+  public void setInstitution(Institution institution) {
+    this.institution = institution;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/entity/Study.java
+++ b/src/main/java/merrittwan/cs3200/entity/Study.java
@@ -1,0 +1,121 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.sql.Date;
+import java.util.List;
+
+/**
+ * Class to represent rows in STUDY table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Study {
+
+  private int studyId;
+
+  private String title;
+
+  private String description;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+  private Date startDate;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+  private Date endDate;
+
+  private PrincipalInvestigator principalInvestigator;
+
+  private MedicalCondition medicalCondition;
+
+  private Boolean completed;
+
+  private Boolean successful;
+
+  private List<StudyDrug> drugs;
+
+  public Study() {
+
+  }
+
+  public int getStudyId() {
+    return studyId;
+  }
+
+  public void setStudyId(int studyId) {
+    this.studyId = studyId;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Date getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(Date startDate) {
+    this.startDate = startDate;
+  }
+
+  public Date getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(Date endDate) {
+    this.endDate = endDate;
+  }
+
+  public PrincipalInvestigator getPrincipalInvestigator() {
+    return principalInvestigator;
+  }
+
+  public void setPrincipalInvestigator(PrincipalInvestigator principalInvestigator) {
+    this.principalInvestigator = principalInvestigator;
+  }
+
+  public MedicalCondition getMedicalCondition() {
+    return medicalCondition;
+  }
+
+  public void setMedicalCondition(MedicalCondition medicalCondition) {
+    this.medicalCondition = medicalCondition;
+  }
+
+  public Boolean isCompleted() {
+    return completed;
+  }
+
+  public void setCompleted(Boolean completed) {
+    this.completed = completed;
+  }
+
+  public Boolean isSuccessful() {
+    return successful;
+  }
+
+  public void setSuccessful(Boolean successful) {
+    this.successful = successful;
+  }
+
+  public List<StudyDrug> getDrugs() {
+    return drugs;
+  }
+
+  public void setDrugs(List<StudyDrug> drugs) {
+    this.drugs = drugs;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/entity/StudyClinician.java
+++ b/src/main/java/merrittwan/cs3200/entity/StudyClinician.java
@@ -1,0 +1,35 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Class to represent rows in STUDY_HAS_CLINICIAN table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StudyClinician {
+
+  private Study study;
+
+  private Clinician clinician;
+
+  public StudyClinician() {
+
+  }
+
+  public Study getStudy() {
+    return study;
+  }
+
+  public void setStudy(Study study) {
+    this.study = study;
+  }
+
+  public Clinician getClinician() {
+    return clinician;
+  }
+
+  public void setClinician(Clinician clinician) {
+    this.clinician = clinician;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/entity/StudyDrug.java
+++ b/src/main/java/merrittwan/cs3200/entity/StudyDrug.java
@@ -1,0 +1,79 @@
+package merrittwan.cs3200.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Class to represent rows in STUDY_DRUG_DETAILS table.
+ * Created by olivi on 11/20/2017.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StudyDrug {
+
+  private int studyId;
+
+  private Drug drug;
+
+  private int dosageAmount;
+
+  private String dosageUnit;
+
+  private int treatmentIntervalTime;
+
+  private IntervalType treatmentIntervalType;
+
+  public Drug getDrug() {
+    return drug;
+  }
+
+  public int getStudyId() {
+    return studyId;
+  }
+
+  public void setStudyId(int studyId) {
+    this.studyId = studyId;
+  }
+
+  public enum IntervalType {
+    MONTH, WEEK, DAY, HOUR, MINUTE
+  }
+
+  public StudyDrug() {
+
+  }
+
+  public void setDrug(Drug drug) {
+    this.drug = drug;
+  }
+
+  public int getDosageAmount() {
+    return dosageAmount;
+  }
+
+  public void setDosageAmount(int dosageAmount) {
+    this.dosageAmount = dosageAmount;
+  }
+
+  public String getDosageUnit() {
+    return dosageUnit;
+  }
+
+  public void setDosageUnit(String dosageUnit) {
+    this.dosageUnit = dosageUnit;
+  }
+
+  public int getTreatmentIntervalTime() {
+    return treatmentIntervalTime;
+  }
+
+  public void setTreatmentIntervalTime(int treatmentIntervalTime) {
+    this.treatmentIntervalTime = treatmentIntervalTime;
+  }
+
+  public IntervalType getTreatmentIntervalType() {
+    return treatmentIntervalType;
+  }
+
+  public void setTreatmentIntervalType(IntervalType treatmentIntervalType) {
+    this.treatmentIntervalType = treatmentIntervalType;
+  }
+}

--- a/src/main/java/merrittwan/cs3200/rowmap/AddressRowMapper.java
+++ b/src/main/java/merrittwan/cs3200/rowmap/AddressRowMapper.java
@@ -1,9 +1,11 @@
-package merrittwan.cs3200.repository;
+package merrittwan.cs3200.rowmap;
 
 import org.springframework.jdbc.core.RowMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import merrittwan.cs3200.entity.Address;
 
 /**
  * Created by olivi on 11/15/2017.

--- a/src/main/java/merrittwan/cs3200/rowmap/AddressRowMapper.java
+++ b/src/main/java/merrittwan/cs3200/rowmap/AddressRowMapper.java
@@ -19,7 +19,7 @@ public class AddressRowMapper implements RowMapper<Address> {
       address.setStreet(resultSet.getString("street"));
       address.setCity(resultSet.getString("city"));
       address.setState(resultSet.getString("state"));
-      address.setZip(resultSet.getInt("zip"));
+      address.setZip(resultSet.getString("zip"));
     } catch (SQLException e) {
       e.printStackTrace();
     }

--- a/src/main/java/merrittwan/cs3200/service/address/AddressService.java
+++ b/src/main/java/merrittwan/cs3200/service/address/AddressService.java
@@ -2,7 +2,7 @@ package merrittwan.cs3200.service.address;
 
 import java.util.List;
 
-import merrittwan.cs3200.repository.Address;
+import merrittwan.cs3200.entity.Address;
 
 /**
  * Created by olivi on 11/17/2017.

--- a/src/main/java/merrittwan/cs3200/service/address/AddressServiceImpl.java
+++ b/src/main/java/merrittwan/cs3200/service/address/AddressServiceImpl.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-import merrittwan.cs3200.repository.Address;
-import merrittwan.cs3200.repository.AddressRowMapper;
+import merrittwan.cs3200.entity.Address;
+import merrittwan.cs3200.rowmap.AddressRowMapper;
 
 /**
  * Created by olivi on 11/15/2017.

--- a/src/main/java/merrittwan/cs3200/service/study/StudyService.java
+++ b/src/main/java/merrittwan/cs3200/service/study/StudyService.java
@@ -1,0 +1,7 @@
+package merrittwan.cs3200.service.study;
+
+/**
+ * Created by olivi on 11/28/2017.
+ */
+public class StudyService {
+}

--- a/src/main/java/merrittwan/cs3200/service/study/StudyServiceImpl.java
+++ b/src/main/java/merrittwan/cs3200/service/study/StudyServiceImpl.java
@@ -1,0 +1,7 @@
+package merrittwan.cs3200.service.study;
+
+/**
+ * Created by olivi on 11/28/2017.
+ */
+public class StudyServiceImpl {
+}


### PR DESCRIPTION
- Moved existing Address object to entity package, creating Java POJOs for remaining db tables.
- Updated request mappings to have /api/ prefix